### PR TITLE
Allow for using the Basic Auth or Bearer Schemes

### DIFF
--- a/src/main/java/org/kamranzafar/jddl/Authentication.java
+++ b/src/main/java/org/kamranzafar/jddl/Authentication.java
@@ -1,61 +1,54 @@
 /**
- * Copyright 2012 Kamran Zafar 
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0 
- * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
- * 
+ * Copyright 2012 Kamran Zafar
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.kamranzafar.jddl;
 
+import org.kamranzafar.jddl.util.Base64;
+
 public class Authentication {
-	public static enum AuthType {
-		BASIC
-	}
 
-	private AuthType authType = AuthType.BASIC;
-	private String username;
-	private String password;
+    public enum AuthType {
+        BASIC, BEARER
+    }
 
-	public Authentication() {
-	}
+    private AuthType authType = AuthType.BASIC;
 
-	public Authentication(String username, String password) {
-		super();
-		this.username = username;
-		this.password = password;
-	}
+    private String token;
 
-	public AuthType getAuthType() {
-		return authType;
-	}
+    private Authentication() {
+    }
 
-	public void setAuthType(AuthType authType) {
-		this.authType = authType;
-	}
+    public static Authentication withBasicAuthentication(final String username, final String password) {
+        Authentication auth = new Authentication();
+        auth.authType = AuthType.BASIC;
+        auth.token = String.format("Basic %s", Base64.encodeBytes(String.format("%s:%s", username, password).getBytes()));
 
-	public String getUsername() {
-		return username;
-	}
+        return auth;
+    }
 
-	public void setUsername(String username) {
-		this.username = username;
-	}
+    public static Authentication withBearerAuthentication(final String token) {
+        Authentication auth = new Authentication();
+        auth.authType = AuthType.BEARER;
+        auth.token = String.format("Bearer %s", token);
 
-	public String getPassword() {
-		return password;
-	}
+        return auth;
+    }
 
-	public void setPassword(String password) {
-		this.password = password;
-	}
+    public String getRequestHeader() {
+        return this.token;
+    }
+
 }


### PR DESCRIPTION
So because the Basic Authentication and Bearer Authentication schemes are near identical in how they are formatted when being added to the Authorization Http Request header, I thought, why not just use a token attribute instead that can then be used to set the Authorization header directly due to already being in the needed format.